### PR TITLE
fix: Jar파일도 1nebook.p12의 path를 찾을 수 있도록 수정

### DIFF
--- a/src/main/java/com/nhnacademy/taskapi/keyManager/service/KeyFactoryManager.java
+++ b/src/main/java/com/nhnacademy/taskapi/keyManager/service/KeyFactoryManager.java
@@ -24,6 +24,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import javax.net.ssl.SSLContext;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.security.*;
 import java.security.cert.CertificateException;
@@ -60,9 +61,16 @@ public class KeyFactoryManager {
 //            ClassPathResource resource = new ClassPathResource(keyPath);
 //            File file = resource.getFile();
 
+            /*
             FileInputStream fis = new FileInputStream(Objects.requireNonNull(getClass().getClassLoader().getResource(keyPath)).getFile());
-
             clientStore.load(fis, password.toCharArray());
+            */
+
+            InputStream keyStoreInputStream = getClass().getClassLoader().getResourceAsStream(keyPath);
+            if (keyStoreInputStream == null) {
+                throw new KeyManagerException("Hexa_certificate.p12 not found in classpath at " + keyPath);
+            }
+            clientStore.load(keyStoreInputStream, password.toCharArray());
 
             // ssl 연결 설정
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,6 +52,6 @@ servlet:
 nhnKey:
   url: https://api-keymanager.nhncloudservice.com
   appKey: qTQNj7LyHhdAazH3
-  keyPath: ./1nebook.p12
+  keyPath: 1nebook.p12
   password: 1nebook
   keyId: 7b34378ad2034b71b2037ca9b1538d41


### PR DESCRIPTION
NHN서버에 올라간 Jar파일이 1nebook.p12의 경로를 찾지 못하는 문제 발생

* FileInputStream : Jar 파일 내부 리소스 접근 불가능
* getResourceAsStream : Jar 파일 내부 리소스도 접근 가능
