### PR TITLE
feat: OrderStatus Entity추가 Response controller 추가

### DIFF
--- a/src/main/java/com/nhnacademy/taskapi/order/controller/OrderController.java
+++ b/src/main/java/com/nhnacademy/taskapi/order/controller/OrderController.java
@@ -32,7 +32,7 @@ public class OrderController {
         return ResponseEntity.ok().body(orderList);
     }
 
-    @GetMapping("/admin/orders")
+    @GetMapping("/task/admin/orders")
     public ResponseEntity<List<OrderResponseDto>> getOrdersByStatusName(@RequestParam String status) {
         List<OrderResponseDto> ordersByStatusName = orderService.getOrdersByStatusName(status);
         return ResponseEntity.ok(ordersByStatusName);

--- a/src/main/java/com/nhnacademy/taskapi/order/controller/OrderController.java
+++ b/src/main/java/com/nhnacademy/taskapi/order/controller/OrderController.java
@@ -1,7 +1,7 @@
 package com.nhnacademy.taskapi.order.controller;
 
 import com.nhnacademy.taskapi.order.dto.OrderCreateDTO;
-import com.nhnacademy.taskapi.order.dto.OrderResponseDTO;
+import com.nhnacademy.taskapi.order.dto.OrderResponseDto;
 import com.nhnacademy.taskapi.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,8 +22,8 @@ public class OrderController {
     }
 
     @GetMapping("/task/orders")
-    public ResponseEntity<List<OrderResponseDTO>> getOrders(@RequestHeader("X-MEMBER-ID") Long memberId) {
-        List<OrderResponseDTO> orderList = orderService.getOrderList(memberId);
+    public ResponseEntity<List<OrderResponseDto>> getOrders(@RequestHeader("X-MEMBER-ID") Long memberId) {
+        List<OrderResponseDto> orderList = orderService.getOrderList(memberId);
 
         // null일 경우 list 반환 방법
         if (orderList == null || orderList.isEmpty()) {
@@ -32,7 +32,11 @@ public class OrderController {
         return ResponseEntity.ok().body(orderList);
     }
 
-
+    @GetMapping("/admin/orders")
+    public ResponseEntity<List<OrderResponseDto>> getOrdersByStatusName(@RequestParam String status) {
+        List<OrderResponseDto> ordersByStatusName = orderService.getOrdersByStatusName(status);
+        return ResponseEntity.ok(ordersByStatusName);
+    }
 
 
 }

--- a/src/main/java/com/nhnacademy/taskapi/order/controller/OrderStatusController.java
+++ b/src/main/java/com/nhnacademy/taskapi/order/controller/OrderStatusController.java
@@ -1,0 +1,22 @@
+package com.nhnacademy.taskapi.order.controller;
+
+import com.nhnacademy.taskapi.order.dto.OrderStatusResponseDto;
+import com.nhnacademy.taskapi.order.service.OrderStatusService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class OrderStatusController {
+
+    private final OrderStatusService orderStatusService;
+
+    @GetMapping("/task/order/statuses")
+    public ResponseEntity<List<String>> getOrderStatuses() {
+        return ResponseEntity.ok(orderStatusService.getOrderStatusesList());
+    }
+}

--- a/src/main/java/com/nhnacademy/taskapi/order/dto/OrderResponseDto.java
+++ b/src/main/java/com/nhnacademy/taskapi/order/dto/OrderResponseDto.java
@@ -8,14 +8,14 @@ import java.time.LocalDateTime;
 
 @AllArgsConstructor
 @Getter
-public class OrderResponseDTO {
+public class OrderResponseDto {
     String orderer;
     LocalDateTime dateTime;
     int deliveryPrice;
     int totalPrice;
 
-    public static OrderResponseDTO fromOrder(Order order) {
-        return new OrderResponseDTO(
+    public static OrderResponseDto fromOrder(Order order) {
+        return new OrderResponseDto(
                 order.getOrderer(),
                 order.getDateTime(),
                 order.getDeliveryPrice(),

--- a/src/main/java/com/nhnacademy/taskapi/order/dto/OrderStatusResponseDto.java
+++ b/src/main/java/com/nhnacademy/taskapi/order/dto/OrderStatusResponseDto.java
@@ -1,0 +1,15 @@
+package com.nhnacademy.taskapi.order.dto;
+
+import com.nhnacademy.taskapi.order.entity.OrderStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class OrderStatusResponseDto {
+    private String orderStatusName;
+
+    public static OrderStatusResponseDto fromOrderStatus(OrderStatus orderStatus) {
+        return new OrderStatusResponseDto(orderStatus.getStatusName());
+    }
+}

--- a/src/main/java/com/nhnacademy/taskapi/order/entity/Order.java
+++ b/src/main/java/com/nhnacademy/taskapi/order/entity/Order.java
@@ -64,6 +64,16 @@ public class Order {
         this.totalPrice = totalPrice;
     }
 
+    public Order(Member member, String orderer, String phoneNumber, LocalDateTime dateTime, int deliveryPrice, int totalPrice, OrderStatus orderStatus) {
+        this.member = member;
+        this.orderer = orderer;
+        this.phoneNumber = phoneNumber;
+        this.dateTime = dateTime;
+        this.deliveryPrice = deliveryPrice;
+        this.totalPrice = totalPrice;
+        this.orderStatus = orderStatus;
+    }
+
     @Override
     public String toString() {
         return "Order{" +

--- a/src/main/java/com/nhnacademy/taskapi/order/entity/Order.java
+++ b/src/main/java/com/nhnacademy/taskapi/order/entity/Order.java
@@ -51,6 +51,10 @@ public class Order {
     @OneToMany(mappedBy = "order")
     List<Delivery> deliveryList;
 
+    @ManyToOne
+    @JoinColumn(name = "order_status_id")
+    OrderStatus orderStatus;
+
     public Order(Member member, String orderer, String phoneNumber, LocalDateTime dateTime, int deliveryPrice, int totalPrice) {
         this.member = member;
         this.orderer = orderer;

--- a/src/main/java/com/nhnacademy/taskapi/order/entity/OrderStatus.java
+++ b/src/main/java/com/nhnacademy/taskapi/order/entity/OrderStatus.java
@@ -16,4 +16,8 @@ public class OrderStatus {
     @UniqueElements
     @Column(name = "order_status_name")
     private String statusName;
+
+    public OrderStatus(String statusName) {
+        this.statusName = statusName;
+    }
 }

--- a/src/main/java/com/nhnacademy/taskapi/order/entity/OrderStatus.java
+++ b/src/main/java/com/nhnacademy/taskapi/order/entity/OrderStatus.java
@@ -2,6 +2,7 @@ package com.nhnacademy.taskapi.order.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import org.hibernate.validator.constraints.UniqueElements;
 
 @Getter
 @Entity
@@ -12,6 +13,7 @@ public class OrderStatus {
     @Column(name = "order_status_id")
     private Long orderStatusId;
 
+    @UniqueElements
     @Column(name = "order_status_name")
     private String statusName;
 }

--- a/src/main/java/com/nhnacademy/taskapi/order/entity/OrderStatus.java
+++ b/src/main/java/com/nhnacademy/taskapi/order/entity/OrderStatus.java
@@ -1,0 +1,17 @@
+package com.nhnacademy.taskapi.order.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "order_Statuses")
+public class OrderStatus {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_status_id")
+    private Long orderStatusId;
+
+    @Column(name = "order_status_name")
+    private String statusName;
+}

--- a/src/main/java/com/nhnacademy/taskapi/order/exception/OrderStatusNotFoundException.java
+++ b/src/main/java/com/nhnacademy/taskapi/order/exception/OrderStatusNotFoundException.java
@@ -1,0 +1,7 @@
+package com.nhnacademy.taskapi.order.exception;
+
+public class OrderStatusNotFoundException extends RuntimeException {
+    public OrderStatusNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/nhnacademy/taskapi/order/repository/OrderRepository.java
+++ b/src/main/java/com/nhnacademy/taskapi/order/repository/OrderRepository.java
@@ -2,10 +2,15 @@ package com.nhnacademy.taskapi.order.repository;
 
 import com.nhnacademy.taskapi.order.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
     List<Order> findByPhoneNumber(String s);
     List<Order> findAllByMemberId(Long memberId);
+
+    @Query("SELECT o FROM Order o JOIN FETCH o.orderStatus WHERE o.orderStatus.statusName = :statusName")
+    List<Order> findByStatusName(@Param("statusName") String statusName);
 }

--- a/src/main/java/com/nhnacademy/taskapi/order/repository/OrderStatusRepository.java
+++ b/src/main/java/com/nhnacademy/taskapi/order/repository/OrderStatusRepository.java
@@ -1,0 +1,8 @@
+package com.nhnacademy.taskapi.order.repository;
+
+import com.nhnacademy.taskapi.order.entity.OrderStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderStatusRepository extends JpaRepository<OrderStatus, Long> {
+
+}

--- a/src/main/java/com/nhnacademy/taskapi/order/repository/OrderStatusRepository.java
+++ b/src/main/java/com/nhnacademy/taskapi/order/repository/OrderStatusRepository.java
@@ -3,6 +3,11 @@ package com.nhnacademy.taskapi.order.repository;
 import com.nhnacademy.taskapi.order.entity.OrderStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface OrderStatusRepository extends JpaRepository<OrderStatus, Long> {
+    Optional<OrderStatus> findByStatusName(String statusName);
+
 
 }

--- a/src/main/java/com/nhnacademy/taskapi/order/service/Impl/OrderServiceImpl.java
+++ b/src/main/java/com/nhnacademy/taskapi/order/service/Impl/OrderServiceImpl.java
@@ -1,14 +1,16 @@
 package com.nhnacademy.taskapi.order.service.Impl;
 
-import com.nhnacademy.taskapi.address.repository.AddressRepository;
 import com.nhnacademy.taskapi.member.domain.Member;
 import com.nhnacademy.taskapi.member.exception.MemberNotFoundException;
 import com.nhnacademy.taskapi.member.repository.MemberRepository;
 import com.nhnacademy.taskapi.order.dto.OrderCreateDTO;
-import com.nhnacademy.taskapi.order.dto.OrderResponseDTO;
+import com.nhnacademy.taskapi.order.dto.OrderResponseDto;
 import com.nhnacademy.taskapi.order.dto.OrdererResponseDto;
 import com.nhnacademy.taskapi.order.entity.Order;
+import com.nhnacademy.taskapi.order.entity.OrderStatus;
+import com.nhnacademy.taskapi.order.exception.OrderStatusNotFoundException;
 import com.nhnacademy.taskapi.order.repository.OrderRepository;
+import com.nhnacademy.taskapi.order.repository.OrderStatusRepository;
 import com.nhnacademy.taskapi.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,7 +24,7 @@ import java.util.List;
 public class OrderServiceImpl implements OrderService {
     private final OrderRepository orderRepository;
     private final MemberRepository memberRepository;
-    private final AddressRepository addressRepository;
+    private final OrderStatusRepository orderStatusRepository;
 
     // create
     @Override
@@ -30,6 +32,9 @@ public class OrderServiceImpl implements OrderService {
 //        if (!memberRepository.existsById(memberId)) {
 //            throw new MemberIllegalArgumentException("Member id " + memberId + " does not exist");
 //        }
+
+        // 주문 상태 default 값 대기
+        OrderStatus waitingStatus = orderStatusRepository.findByStatusName("결제대기").orElseThrow(() -> new OrderStatusNotFoundException("OrderStatus is not found; error!!"));
 
         Member findMember = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException("Member id " + memberId + " does not exist"));
@@ -40,7 +45,8 @@ public class OrderServiceImpl implements OrderService {
             orderCreateDTO.getPhoneNumber(),
             orderCreateDTO.getDateTime(),
             orderCreateDTO.getDeliveryPrice(),
-            orderCreateDTO.getTotalPrice()
+            orderCreateDTO.getTotalPrice(),
+            waitingStatus
         );
         orderRepository.save(order);
     }
@@ -48,11 +54,11 @@ public class OrderServiceImpl implements OrderService {
     // read
     @Transactional(readOnly = true)
     @Override
-    public List<OrderResponseDTO> getOrderList(Long memberId) {
+    public List<OrderResponseDto> getOrderList(Long memberId) {
         memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException("Member id" + memberId + " dose not exist"));
 
-        List<OrderResponseDTO> dtoList = orderRepository.findAllByMemberId(memberId).stream()
-                .map(OrderResponseDTO::fromOrder).toList();
+        List<OrderResponseDto> dtoList = orderRepository.findAllByMemberId(memberId).stream()
+                .map(OrderResponseDto::fromOrder).toList();
 
         return dtoList;
     }
@@ -60,7 +66,6 @@ public class OrderServiceImpl implements OrderService {
     @Override
     public OrdererResponseDto getOrderer(Long memberId) {
         memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException("Member id" + memberId + " dose not exist"));
-
 
         String ordererName = memberRepository.findById(memberId).get().getName();
         String ordererPhoneNumber = memberRepository.findById(memberId).get().getPhoneNumber();
@@ -73,6 +78,13 @@ public class OrderServiceImpl implements OrderService {
         String recipientRequestedTerm;
 
         return null;
+    }
+
+    @Override
+    public List<OrderResponseDto> getOrdersByStatusName(String statusName) {
+        orderStatusRepository.findByStatusName(statusName).orElseThrow(() -> new OrderStatusNotFoundException("OrderStatus is not found; error!!"));
+
+        return orderRepository.findByStatusName(statusName).stream().map(OrderResponseDto::fromOrder).toList();
     }
 
     //    public List<OrderDetail> getOrderDetailList(Long orderId) {

--- a/src/main/java/com/nhnacademy/taskapi/order/service/Impl/OrderStatusServiceImpl.java
+++ b/src/main/java/com/nhnacademy/taskapi/order/service/Impl/OrderStatusServiceImpl.java
@@ -1,0 +1,35 @@
+package com.nhnacademy.taskapi.order.service.Impl;
+
+import com.nhnacademy.taskapi.order.dto.OrderStatusResponseDto;
+import com.nhnacademy.taskapi.order.entity.OrderStatus;
+import com.nhnacademy.taskapi.order.repository.OrderStatusRepository;
+import com.nhnacademy.taskapi.order.service.OrderStatusService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class OrderStatusServiceImpl implements OrderStatusService {
+    private final OrderStatusRepository orderStatusRepository;
+
+    // create
+
+    // read
+    @Override
+    public List<String> getOrderStatusesList() {
+        List<String> orderResponseList = new ArrayList<>();
+
+        for (OrderStatus orderStatus : orderStatusRepository.findAll()) {
+            orderResponseList.add(orderStatus.getStatusName());
+        }
+
+        /*
+        orderStatusName을 담은 객체를 넘길까? List<String>에 담아서 넘길까?
+        return orderStatusRepository.findAll().stream().map(OrderStatusResponseDto::fromOrderStatus).toList();
+         */
+        return orderResponseList;
+    }
+}

--- a/src/main/java/com/nhnacademy/taskapi/order/service/OrderService.java
+++ b/src/main/java/com/nhnacademy/taskapi/order/service/OrderService.java
@@ -1,13 +1,14 @@
 package com.nhnacademy.taskapi.order.service;
 
 import com.nhnacademy.taskapi.order.dto.OrderCreateDTO;
-import com.nhnacademy.taskapi.order.dto.OrderResponseDTO;
+import com.nhnacademy.taskapi.order.dto.OrderResponseDto;
 import com.nhnacademy.taskapi.order.dto.OrdererResponseDto;
 
 import java.util.List;
 
 public interface OrderService {
     void saveOrder(Long member_id, OrderCreateDTO orderCreateDTO);
-    List<OrderResponseDTO> getOrderList(Long memberId);
+    List<OrderResponseDto> getOrderList(Long memberId);
     OrdererResponseDto getOrderer(Long memberId);
+    List<OrderResponseDto> getOrdersByStatusName(String statusName);
 }

--- a/src/main/java/com/nhnacademy/taskapi/order/service/OrderStatusService.java
+++ b/src/main/java/com/nhnacademy/taskapi/order/service/OrderStatusService.java
@@ -1,0 +1,9 @@
+package com.nhnacademy.taskapi.order.service;
+
+import com.nhnacademy.taskapi.order.dto.OrderStatusResponseDto;
+
+import java.util.List;
+
+public interface OrderStatusService {
+    List<String> getOrderStatusesList();
+}

--- a/src/main/java/com/nhnacademy/taskapi/packaging/controller/PackagingController.java
+++ b/src/main/java/com/nhnacademy/taskapi/packaging/controller/PackagingController.java
@@ -1,10 +1,9 @@
 package com.nhnacademy.taskapi.packaging.controller;
 
 import com.nhnacademy.taskapi.packaging.dto.PackagingRequestDto;
-import com.nhnacademy.taskapi.packaging.dto.PackagingResponseDTO;
+import com.nhnacademy.taskapi.packaging.dto.PackagingResponseDto;
 import com.nhnacademy.taskapi.packaging.service.PackagingService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -17,8 +16,8 @@ public class PackagingController {
 
     // TODO ResponseEntity 등록
     @GetMapping("/task/packagings")
-    public List<PackagingResponseDTO> packaging() {
-        List<PackagingResponseDTO> allPackaging = packagingService.getAllPackaging();
+    public List<PackagingResponseDto> packaging() {
+        List<PackagingResponseDto> allPackaging = packagingService.getAllPackaging();
         return allPackaging;
     }
 

--- a/src/main/java/com/nhnacademy/taskapi/packaging/dto/PackagingResponseDto.java
+++ b/src/main/java/com/nhnacademy/taskapi/packaging/dto/PackagingResponseDto.java
@@ -1,25 +1,20 @@
 package com.nhnacademy.taskapi.packaging.dto;
 
-import com.nhnacademy.taskapi.order.dto.OrderResponseDTO;
-import com.nhnacademy.taskapi.order.entity.Order;
 import com.nhnacademy.taskapi.packaging.entity.Packaging;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-public class PackagingResponseDTO {
+public class PackagingResponseDto {
     int id;
     String name;
     int price;
 
-    public static PackagingResponseDTO fromPackaging(Packaging packaging) {
-        return new PackagingResponseDTO(
+    public static PackagingResponseDto fromPackaging(Packaging packaging) {
+        return new PackagingResponseDto(
                 packaging.getId(),
                 packaging.getName(),
                 packaging.getPrice()

--- a/src/main/java/com/nhnacademy/taskapi/packaging/service/Impl/PackagingServiceImpl.java
+++ b/src/main/java/com/nhnacademy/taskapi/packaging/service/Impl/PackagingServiceImpl.java
@@ -1,7 +1,7 @@
 package com.nhnacademy.taskapi.packaging.service.Impl;
 
 import com.nhnacademy.taskapi.packaging.dto.PackagingRequestDto;
-import com.nhnacademy.taskapi.packaging.dto.PackagingResponseDTO;
+import com.nhnacademy.taskapi.packaging.dto.PackagingResponseDto;
 import com.nhnacademy.taskapi.packaging.entity.Packaging;
 import com.nhnacademy.taskapi.packaging.exception.PackagingAlreadyExistException;
 import com.nhnacademy.taskapi.packaging.exception.PackagingNotFoundException;
@@ -34,8 +34,8 @@ public class PackagingServiceImpl implements PackagingService {
     }
 
     // read
-    public List<PackagingResponseDTO> getAllPackaging() {
-        List<PackagingResponseDTO> list = packagingRepository.findAll().stream().map(PackagingResponseDTO::fromPackaging).toList();
+    public List<PackagingResponseDto> getAllPackaging() {
+        List<PackagingResponseDto> list = packagingRepository.findAll().stream().map(PackagingResponseDto::fromPackaging).toList();
         return list;
     };
 

--- a/src/main/java/com/nhnacademy/taskapi/packaging/service/PackagingService.java
+++ b/src/main/java/com/nhnacademy/taskapi/packaging/service/PackagingService.java
@@ -1,7 +1,7 @@
 package com.nhnacademy.taskapi.packaging.service;
 
 import com.nhnacademy.taskapi.packaging.dto.PackagingRequestDto;
-import com.nhnacademy.taskapi.packaging.dto.PackagingResponseDTO;
+import com.nhnacademy.taskapi.packaging.dto.PackagingResponseDto;
 import com.nhnacademy.taskapi.packaging.entity.Packaging;
 
 import java.util.List;
@@ -11,7 +11,7 @@ public interface PackagingService {
     void createPackaging(PackagingRequestDto packagingRequestDto);
 
     // read
-    public List<PackagingResponseDTO> getAllPackaging();
+    public List<PackagingResponseDto> getAllPackaging();
     public Packaging getPackagingById(int id);
 
     // update

--- a/src/test/java/com/nhnacademy/taskapi/order/service/Impl/OrderServiceImplTest.java
+++ b/src/test/java/com/nhnacademy/taskapi/order/service/Impl/OrderServiceImplTest.java
@@ -5,7 +5,9 @@ import com.nhnacademy.taskapi.member.exception.MemberNotFoundException;
 import com.nhnacademy.taskapi.member.repository.MemberRepository;
 import com.nhnacademy.taskapi.order.dto.OrderCreateDTO;
 import com.nhnacademy.taskapi.order.entity.Order;
+import com.nhnacademy.taskapi.order.entity.OrderStatus;
 import com.nhnacademy.taskapi.order.repository.OrderRepository;
+import com.nhnacademy.taskapi.order.repository.OrderStatusRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,6 +33,9 @@ class OrderServiceImplTest {
     @Mock
     private OrderRepository orderRepository;
 
+    @Mock
+    private OrderStatusRepository orderStatusRepository;
+
 //    private OrderCreateDTO orderCreateDTO;
 
     @BeforeEach
@@ -51,6 +56,7 @@ class OrderServiceImplTest {
     void saveMember() {
         // given
         Long memberId = 1L;
+        when(orderStatusRepository.findByStatusName("결제대기")).thenReturn(Optional.of(new OrderStatus("결제대기")));
         OrderCreateDTO orderCreateDTO = new OrderCreateDTO("김선준", "010-9999-9999", LocalDateTime.now(), 3000, 25000);
         when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
 
@@ -68,8 +74,8 @@ class OrderServiceImplTest {
         // given
         Long memberId = 1L;
         OrderCreateDTO orderCreateDTO = new OrderCreateDTO("김선준", "010-9999-9999", LocalDateTime.now(), 3000, 25000);
-
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(mockMember()));
+        when(orderStatusRepository.findByStatusName("결제대기")).thenReturn(Optional.of(new OrderStatus("결제대기")));
 
         // when
         orderService.saveOrder(1L, orderCreateDTO);


### PR DESCRIPTION
orderStatus (대기, 배송중, 배송완료, 환불, 반품 등)을 enum이 아닌 하나의 테이블로 관리되는게 편할거라 판단되어 Entity를 추가했습니다.

orderStatus를 어떻게 front에 반환할지 고민이되어
1. "orderStatusName"을 갖는 "OrderStatusResponseDto" 객체 반환하기 -> [{"name":"배송중"}, {"name":"대기"}, {"name":"환불"}]
2. "orderStatusName"을 List에 담아 List<String> 반환하기 -> ["배송중", "대기", "환불"]

2번 List<String>으로 결정했는데, 의견이있으면 말씀 부탁드립니다.