### PR TITLE
중복 쿠폰 발급 제한

### DIFF
--- a/src/main/java/com/nhnacademy/taskapi/coupon/exception/AlreadyIssuedCouponException.java
+++ b/src/main/java/com/nhnacademy/taskapi/coupon/exception/AlreadyIssuedCouponException.java
@@ -1,0 +1,7 @@
+package com.nhnacademy.taskapi.coupon.exception;
+
+public class AlreadyIssuedCouponException extends RuntimeException {
+    public AlreadyIssuedCouponException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/nhnacademy/taskapi/coupon/repository/coupons/CouponBoxQueryRepository.java
+++ b/src/main/java/com/nhnacademy/taskapi/coupon/repository/coupons/CouponBoxQueryRepository.java
@@ -1,7 +1,9 @@
 package com.nhnacademy.taskapi.coupon.repository.coupons;
 
+import com.nhnacademy.taskapi.coupon.domain.entity.coupons.Coupon;
 import com.nhnacademy.taskapi.coupon.domain.entity.coupons.IssuedCoupon;
 import com.nhnacademy.taskapi.coupon.domain.entity.coupons.QIssuedCoupon;
+import com.nhnacademy.taskapi.coupon.domain.entity.policies.*;
 import com.nhnacademy.taskapi.coupon.domain.entity.status.CouponStatus;
 import com.nhnacademy.taskapi.member.domain.Member;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -45,5 +47,65 @@ public class CouponBoxQueryRepository {
                 .stream().count();
 
         return new PageImpl<>(content,pageable,total);
+    }
+
+    public boolean checkDuplicatedIssueRateCouponForBook(Member member , Policy policy){
+
+        QIssuedCoupon issuedCoupon = QIssuedCoupon.issuedCoupon;
+
+        long count = jpaQueryFactory
+                .selectFrom(issuedCoupon)
+                .where(
+                        issuedCoupon.member.eq(member),
+                        issuedCoupon.coupon.ratePolicyForBook.isNotNull(),
+                        issuedCoupon.coupon.ratePolicyForBook.eq((RatePolicyForBook) policy)
+                ).stream().count();
+
+        return count <= 0 ;
+    }
+
+    public boolean checkDuplicatedIssueRateCouponForCategory(Member member , Policy policy){
+
+        QIssuedCoupon issuedCoupon = QIssuedCoupon.issuedCoupon;
+
+        long count = jpaQueryFactory
+                .selectFrom(issuedCoupon)
+                .where(
+                        issuedCoupon.member.eq(member),
+                        issuedCoupon.coupon.ratePolicyForCategory.isNotNull(),
+                        issuedCoupon.coupon.ratePolicyForCategory.eq((RatePolicyForCategory) policy)
+                ).stream().count();
+
+        return count <= 0 ;
+    }
+
+    public boolean checkDuplicatedIssuePriceCouponForBook(Member member , Policy policy){
+
+        QIssuedCoupon issuedCoupon = QIssuedCoupon.issuedCoupon;
+
+        long count = jpaQueryFactory
+                .selectFrom(issuedCoupon)
+                .where(
+                        issuedCoupon.member.eq(member),
+                        issuedCoupon.coupon.pricePolicyForBook.isNotNull(),
+                        issuedCoupon.coupon.pricePolicyForBook.eq((PricePolicyForBook) policy)
+                ).stream().count();
+
+        return count <= 0 ;
+    }
+
+    public boolean checkDuplicatedIssuePriceCouponForCategory(Member member , Policy policy){
+
+        QIssuedCoupon issuedCoupon = QIssuedCoupon.issuedCoupon;
+
+        long count = jpaQueryFactory
+                .selectFrom(issuedCoupon)
+                .where(
+                        issuedCoupon.member.eq(member),
+                        issuedCoupon.coupon.pricePolicyForCategory.isNotNull(),
+                        issuedCoupon.coupon.pricePolicyForCategory.eq((PricePolicyForCategory) policy)
+                ).stream().count();
+
+        return count <= 0 ;
     }
 }

--- a/src/main/java/com/nhnacademy/taskapi/coupon/repository/coupons/CouponBoxRepository.java
+++ b/src/main/java/com/nhnacademy/taskapi/coupon/repository/coupons/CouponBoxRepository.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.taskapi.coupon.repository.coupons;
 
+import com.nhnacademy.taskapi.coupon.domain.entity.coupons.Coupon;
 import com.nhnacademy.taskapi.coupon.domain.entity.coupons.IssuedCoupon;
 import com.nhnacademy.taskapi.coupon.domain.entity.status.CouponStatus;
 import com.nhnacademy.taskapi.member.domain.Member;
@@ -9,4 +10,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CouponBoxRepository extends JpaRepository<IssuedCoupon, Long> {
 
+    boolean existsIssuedCouponByCouponAndMember(Coupon coupon, Member member);
 }


### PR DESCRIPTION
쿠폰 발급시 couponBoxService에서
아이디와 쿠폰의 정책ID를 확인해
해당 사용자가 동일한 정책의 쿠폰을 발급받은 이력이 있는지 체크