### PR TITLE
coupon-holder 오류수정

### DIFF
--- a/src/main/java/com/nhnacademy/taskapi/coupon/service/coupons/CouponBoxService.java
+++ b/src/main/java/com/nhnacademy/taskapi/coupon/service/coupons/CouponBoxService.java
@@ -105,7 +105,7 @@ public class CouponBoxService {
             return couponBoxQueryRepository.checkDuplicatedIssuePriceCouponForBook(member,coupon.getPricePolicyForBook());
         }
         if(coupon.getPricePolicyForCategory() != null){
-            couponBoxQueryRepository.checkDuplicatedIssuePriceCouponForCategory(member,coupon.getPricePolicyForCategory());
+            return couponBoxQueryRepository.checkDuplicatedIssuePriceCouponForCategory(member,coupon.getPricePolicyForCategory());
         }
 
         throw new CouponHasNoPolicyExceptioin("쿠폰이 어떠한 정책도 가지고 있지 않습니다, 잘못된 쿠폰입니다");

--- a/src/main/java/com/nhnacademy/taskapi/coupon/service/coupons/CouponService.java
+++ b/src/main/java/com/nhnacademy/taskapi/coupon/service/coupons/CouponService.java
@@ -221,7 +221,7 @@ public class CouponService {
         LocalDateTime endDate = startDate.plusDays(30);
         PolicyStatus policyStatus = policyStatusRepository.findByName("사용됨");
         CouponStatus couponStatus = couponStatusRepository.findByName("발급-삭제가능");
-        Category category = categoryRepository.findByName("전체");
+        Category category = categoryRepository.findByName("국내도서");
 
         RatePolicyForCategory ratePolicyForCategory =
                 ratePoliciesForCategoryRepository.save(

--- a/src/main/java/com/nhnacademy/taskapi/coupon/service/policies/PolicyService.java
+++ b/src/main/java/com/nhnacademy/taskapi/coupon/service/policies/PolicyService.java
@@ -402,7 +402,7 @@ public class PolicyService {
 
         if(policy instanceof  RatePolicyForBook){
             return couponQueryRepository
-                    .getValidCouponCountByPricePolicyForBook(((RatePolicyForBook) policy)
+                    .getValidCouponCountByRatePolicyForBook(((RatePolicyForBook) policy)
                             .getRatePolicyForBookId(),couponStatus);
         }else if(policy instanceof  RatePolicyForCategory){
             return couponQueryRepository.getValidCouponCountByRatePolicyForCategory(((RatePolicyForCategory) policy)


### PR DESCRIPTION
- coupon-holder 페이지에서 rate policy for book 으로 생성한 쿠폰의 잔여수량이 0으로만 표시되던 문제를 해결했습니다
- coupon-holder 페이지에서 price policy for category 쿠폰을 발급받을수 없던 문제를 해결했습니다.